### PR TITLE
Update queue size

### DIFF
--- a/conf/examples/gtex_1gb_jax.config
+++ b/conf/examples/gtex_1gb_jax.config
@@ -1,6 +1,6 @@
 params {
 	gencodeFile              = "gs://robinson-bucket/inputs/rmats/annotations/gencode.v30.annotation.gtf"
-	keyFile                  = "gs://robinson-bucket/inputs/rmats/keys/prj_13460.ngc"
+	keyFile                  = "gs://robinson-bucket/inputs/rmats/keys/prj_17480_D15449.ngc"
 	output                   = "results"
 	readType                 = "paired"
 	readLength               = 76

--- a/conf/examples/top50female_breast.config
+++ b/conf/examples/top50female_breast.config
@@ -1,8 +1,8 @@
 params {
 	gencodeFile              = "gs://robinson-bucket/inputs/rmats/annotations/gencode.v30.annotation.gtf"
-	keyFile                  = "gs://robinson-bucket/inputs/rmats/keys/prj_13460.ngc"
+	keyFile                  = "gs://robinson-bucket/inputs/rmats/keys/prj_17480_D15449.ngc"
 	output                   = "results"
 	readType                 = "paired"
-	readLength               = 50
+	readLength               = 76
 	accessionList            = "gs://robinson-bucket/inputs/rmats/accessions/SraIDs.noCram.noExome.noWGS.totalRNA.Breast.female.sortedByBasePairs.top50BasePairs.txt"
 }

--- a/conf/examples/top50male_breast.config
+++ b/conf/examples/top50male_breast.config
@@ -1,6 +1,6 @@
 params {
 	gencodeFile              = "gs://robinson-bucket/inputs/rmats/annotations/gencode.v30.annotation.gtf"
-	keyFile                  = "gs://robinson-bucket/inputs/rmats/keys/prj_13460.ngc"
+	keyFile                  = "gs://robinson-bucket/inputs/rmats/keys/prj_17480_D15449.ngc"
 	output                   = "results"
 	readType                 = "paired"
 	readLength               = 50

--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -1,7 +1,9 @@
 google {
     lifeSciences.bootDiskSize = 100.GB
     lifeSciences.preemptible = true
-    region = 'europe-west2'
+    zone = 'us-east1-b'
+    network = 'jax-poc-lifebit-01-vpc-network'
+    subnetwork = 'us-east1'
 }
 
 docker.enabled = true
@@ -9,18 +11,15 @@ docker.enabled = true
 process {
 	
     cache = 'lenient'
-
-    executor = 'google-lifesciences'
-    
-    container = 'nfcore/rnaseq:1.3'
-
-    errorStrategy { task.exitStatus == 14 ? 'retry' : 'terminate' }
+    errorStrategy = { task.attempt <= 100 ? 'retry' : 'ignore' }
     maxRetries = 100
+    container = 'nfcore/rnaseq:1.3'
+    
 
     withName: 'getAccession' {
         container = 'gcr.io/nextflow-250616/sratools'
-        cpus = 8
-        memory = '30 GB'
+        cpus = 4
+        memory = '10 GB'
     }
     withName: 'trimming' {
         container = 'gcr.io/nextflow-250616/fastp:latest'
@@ -28,22 +27,25 @@ process {
         memory = '31 GB'
     }
     withName: 'mapping' {
+        errorStrategy = 'ignore'
         container = 'gcr.io/nextflow-250616/hisat2index:samtools'
         cpus = 24
-        memory = '60 GB'
-    }
-    withName: 'sortbam' {
-        cpus = 8
         memory = '30 GB'
     }
-    withName: 'markduplicates' {
+    withName: 'bamstats' {
         errorStrategy = 'ignore'
-        cpus = 10
+    }
+    withName: 'sortbam' {
+        cpus = 4
+        memory = '10 GB'
+    }
+    withName: 'markduplicates' {
+        cpus = 6
         memory = '32 GB'
     }
     withName: 'paired_rmats' {
-        cpus = 16
-        memory = '60 GB'
+        cpus = 2
+        memory = '8 GB'
     }
     withName: 'sampleCountsSave' {
         cpus = 1
@@ -57,7 +59,12 @@ process {
     withLabel: 'rmats' {
         container = 'pprietob/rmats:latest'
     }
-    withLabel: 'rmats' {
+    withLabel: 'postrmats' {
         container = 'pprietob/postrmats:latest'
     }
+}
+
+executor {
+  name = 'google-lifesciences'
+  queueSize = 500
 }

--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -13,8 +13,8 @@ process {
     cache = 'lenient'
     errorStrategy = { task.attempt <= 100 ? 'retry' : 'ignore' }
     maxRetries = 100
-    container = 'nfcore/rnaseq:1.3'
-    
+    maxForks   = 500
+    container  = 'nfcore/rnaseq:1.3'
 
     withName: 'getAccession' {
         container = 'gcr.io/nextflow-250616/sratools'

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     starIndexPath           = "/index/GRCh38_gencode.v30"
     splitNumber             = 2
     skipTrimming            = true
+    reads 		            = false
 
     cutoffSplicingDifference = 0.001
     analysisType = 'U'
@@ -29,8 +30,12 @@ params {
 }
 profiles {
     standard { 
-	includeConfig 'conf/executors/google_pipelines.config'
-	includeConfig 'conf/examples/gtex_1gb.config'  
+        includeConfig 'conf/executors/google_pipelines.config'
+        includeConfig 'conf/examples/top50female_breast.config'
+    }
+    top50female { 
+        includeConfig 'conf/executors/google_pipelines.config'
+        includeConfig 'conf/examples/gtex_1gb.config'
     }
     docker { docker.enabled = true }
     google_pipelines { includeConfig 'conf/executors/google_pipelines.config' }


### PR DESCRIPTION
This PR syncs this repo with the latest changes from the experimental fork [pprieto/rmats-nf-private@2c70e5f](https://github.com/pprieto/rmats-nf-private-fork/commit/2c70e5fa51bf0782a49a447b543491056100b5fd).

Here is a test job on the Lifebit CloudOS platform:
https://cloudos.lifebit.ai/public/jobs/5e6fe94160c9c501032a3ee2

The updates include:
- explicit declarationof `queueSize` set equal to 500
- lenient `errorStrategy` for all processes (allows for 100 retries until the process is finally ignored)
- executor set to `google-lifesciences`