### PR TITLE
Adds * outputs in rmats (file for Anne)

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -288,6 +288,7 @@ process paired_rmats {
     output:
     set val(sample1Name), val(sample2Name), file('rmats_output') into rmatsCounts
     file 'rmats_output/ASEvents/fromGTF*' into fromGtf
+    file("*")
 
     script:
     """


### PR DESCRIPTION
Adding `file("o")` in the outputDir in the paired rmats process to retrieve a table that Anne needs for some final plots (`SplicingIndex_chr` relevant).

